### PR TITLE
Catalog properties fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,7 @@ This tap:
 
 2. Create the config file
 
-    Create a JSON file containing your API key, start date, email and events.
-    The Klaviyo events you want to replicate each have a unique metric ID that needs
-    to be added to the config file.
-    Use -l option to list all available Klaviyo metrics in your account.
+    Create a JSON file containing your API key, start date, and email.
 
     ```json
     {

--- a/README.md
+++ b/README.md
@@ -28,10 +28,7 @@ This tap:
     Use -l option to list all available Klaviyo metrics in your account.
 
     ```json
-    {
-        "credentials": {
-            "api_key": "pk_XYZ"
-        },
+        "api_key": "pk_XYZ",
         "start_date": "2017-01-01T00:00:00Z",
         "user_agent": "email_address",
     }

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Singer taps function in two modes: [discovery mode](https://github.com/singer-io
 
 - Option 1: To select a stream to sync, add `{"breadcrumb": [], "metadata": {"selected": true}}` to its "metadata" entry.
 
-- Option 2: You can use an open-source tool called [Singer Discover](https://github.com/chrisgoddard/singer-discover) to format the catalog.json file.
+- Option 2: Use an open-source tool called [Singer Discover](https://github.com/chrisgoddard/singer-discover) to format the catalog.json file.
     
     
 5. [Optional] Create the initial state file

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ This tap:
 - Incrementally pulls data based on the input state for incremental endpoints
 - Updates full tables for global exclusions and lists endpoints
 
+Singer taps function in two modes: [discovery mode] (https://github.com/singer-io/getting-started/blob/master/docs/DISCOVERY_MODE.md) and [sync mode] (https://github.com/singer-io/getting-started/blob/master/docs/SYNC_MODE.md).
+
 ## Quick start
 
 1. Install
@@ -44,6 +46,10 @@ This tap:
     }
     ```
 
+Before running the tap in Sync mode, you must run the tap in Discover mode and pipe the output into the catalog file.
+
+
+
 4. [Optional] Run discover command and save catalog into catalog file
 
     ```bash
@@ -62,7 +68,7 @@ This tap:
 
 ## Debugging
 
-If you have made changes to your repository, you may need to run the following command after navigating to your local repository:
+If you have made changes to your repository, you may need to run the following command after navigating to your local repository (before running the tap):
 
     
     pip install -e .

--- a/README.md
+++ b/README.md
@@ -69,7 +69,10 @@ If you have made changes to your repository, you may need to run the following c
     pip install -e .
     
 
-# Formatting catalog.json
+## Formatting catalog.json
+You can format catalog.json to select which streams should be synced when the tap is run in sync mode. This [link](https://github.com/singer-io/getting-started/blob/master/docs/SYNC_MODE.md) explains the process of formatting catalog.json for stream selection (scroll to "Stream/Field Selection).
+
+You can also use an [open-source tool called Singer Discover](https://github.com/chrisgoddard/singer-discover) to format the catalog.json file.
 
 
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This tap:
 - Incrementally pulls data based on the input state for incremental endpoints
 - Updates full tables for global exclusions and lists endpoints
 
-Singer taps function in two modes: [discovery mode] (https://github.com/singer-io/getting-started/blob/master/docs/DISCOVERY_MODE.md) and [sync mode] (https://github.com/singer-io/getting-started/blob/master/docs/SYNC_MODE.md).
+Singer taps function in two modes: [discovery mode](https://github.com/singer-io/getting-started/blob/master/docs/DISCOVERY_MODE.md) and [sync mode](https://github.com/singer-io/getting-started/blob/master/docs/SYNC_MODE.md).
 
 ## Quick start
 

--- a/README.md
+++ b/README.md
@@ -48,33 +48,10 @@ To select a stream to sync, add {"breadcrumb": [], "metadata": {"selected": true
 
 The following example syncs the pipelines stream:
 
-...
-    "type": [
-      "null",
-      "object"
-    ],
-    "additionalProperties": false
-  },
-  "stream": "pipelines",
-  "metadata": [{"breadcrumb": [], "metadata": {"selected": true}}]
-},
-...
 
 *Option 2:*
 Add "selected": true to the stream's schema.
 
-...
-"tap_stream_id": "workflows",
-"key_properties": [],
-"schema": {
-  "selected": true,
-  "properties": {
-    "_pipeline_id": {
-      "type": [
-        "null",
-        "string"
-      ]
-...
 
 *Option 3:*
 You can use an [open-source tool called Singer Discover](https://github.com/chrisgoddard/singer-discover) to format the catalog.json file.

--- a/README.md
+++ b/README.md
@@ -44,16 +44,9 @@ Singer taps function in two modes: [discovery mode](https://github.com/singer-io
 This [link](https://github.com/singer-io/getting-started/blob/master/docs/SYNC_MODE.md) explains the process of formatting catalog.json for stream selection (scroll to "Stream/Field Selection).
 
 *Option 1:* 
-To select a stream to sync, add {"breadcrumb": [], "metadata": {"selected": true}} to its "metadata" entry.
-
-The following example syncs the pipelines stream:
-
+To select a stream to sync, add `{"breadcrumb": [], "metadata": {"selected": true}}` to its "metadata" entry.
 
 *Option 2:*
-Add "selected": true to the stream's schema.
-
-
-*Option 3:*
 You can use an [open-source tool called Singer Discover](https://github.com/chrisgoddard/singer-discover) to format the catalog.json file.
     
     

--- a/README.md
+++ b/README.md
@@ -63,13 +63,12 @@ This tap:
 
 
 
-# Debugging
+## Debugging
 
 If you have made changes to your repository, you may need to run the following command after navigating to your local repository:
 
-    ```bash
+    
     pip install -e .
-    ```
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -43,9 +43,9 @@ Singer taps function in two modes: [discovery mode](https://github.com/singer-io
 4. Select streams to sync in catalog.json file
 [This link](https://github.com/singer-io/getting-started/blob/master/docs/SYNC_MODE.md) explains the process of formatting catalog.json for stream selection (scroll to "Stream/Field Selection).
 
-Option 1: To select a stream to sync, add `{"breadcrumb": [], "metadata": {"selected": true}}` to its "metadata" entry.
+- Option 1: To select a stream to sync, add `{"breadcrumb": [], "metadata": {"selected": true}}` to its "metadata" entry.
 
-Option 2: You can use an open-source tool called [Singer Discover](https://github.com/chrisgoddard/singer-discover) to format the catalog.json file.
+- Option 2: You can use an open-source tool called [Singer Discover](https://github.com/chrisgoddard/singer-discover) to format the catalog.json file.
     
     
 5. [Optional] Create the initial state file

--- a/README.md
+++ b/README.md
@@ -41,13 +41,11 @@ Singer taps function in two modes: [discovery mode](https://github.com/singer-io
     ```
 
 4. Select streams to sync in catalog.json file
-This [link](https://github.com/singer-io/getting-started/blob/master/docs/SYNC_MODE.md) explains the process of formatting catalog.json for stream selection (scroll to "Stream/Field Selection).
+[This link](https://github.com/singer-io/getting-started/blob/master/docs/SYNC_MODE.md) explains the process of formatting catalog.json for stream selection (scroll to "Stream/Field Selection).
 
-*Option 1:* 
-To select a stream to sync, add `{"breadcrumb": [], "metadata": {"selected": true}}` to its "metadata" entry.
+Option 1: To select a stream to sync, add `{"breadcrumb": [], "metadata": {"selected": true}}` to its "metadata" entry.
 
-*Option 2:*
-You can use an [open-source tool called Singer Discover](https://github.com/chrisgoddard/singer-discover) to format the catalog.json file.
+Option 2: You can use an open-source tool called [Singer Discover](https://github.com/chrisgoddard/singer-discover) to format the catalog.json file.
     
     
 5. [Optional] Create the initial state file

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This tap:
 - Incrementally pulls data based on the input state for incremental endpoints
 - Updates full tables for global exclusions and lists endpoints
 
-Singer taps function in two modes: [discovery mode](https://github.com/singer-io/getting-started/blob/master/docs/DISCOVERY_MODE.md) and [sync mode](https://github.com/singer-io/getting-started/blob/master/docs/SYNC_MODE.md).
+Singer taps function in two modes: [discovery mode](https://github.com/singer-io/getting-started/blob/master/docs/DISCOVERY_MODE.md) and [sync mode](https://github.com/singer-io/getting-started/blob/master/docs/SYNC_MODE.md). Before running the tap in sync mode, you should run the tap in discovery mode and direct the output to a file called catalog.json, which can be used as an input to run the tap in sync mode and to specify which streams should be synced (see Step 4).
 
 ## Quick start
 
@@ -46,14 +46,10 @@ Singer taps function in two modes: [discovery mode](https://github.com/singer-io
     }
     ```
 
-Before running the tap in Sync mode, you must run the tap in Discover mode and pipe the output into the catalog file.
-
-
-
 4. [Optional] Run discover command and save catalog into catalog file
 
     ```bash
-    tap-klaviyo --config config.json --discover
+    tap-klaviyo --config config.json --discover > catalog.json
     ```
 
 5. Run the application
@@ -70,8 +66,12 @@ Before running the tap in Sync mode, you must run the tap in Discover mode and p
 
 If you have made changes to your repository, you may need to run the following command after navigating to your local repository (before running the tap):
 
-    
     pip install -e .
+    
+
+# Formatting catalog.json
+
+
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,16 @@ This tap:
     tap-klaviyo --config config.json [--state state.json] [--catalog catalog.json]
     ```
 
----
 
+
+# Debugging
+
+If you have made changes to your repository, you may need to run the following command after navigating to your local repository:
+
+    ```bash
+    pip install -e .
+    ```
+
+---
 
 Copyright &copy; 2017 Stitch

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ This tap:
     Use -l option to list all available Klaviyo metrics in your account.
 
     ```json
+    {
         "api_key": "pk_XYZ",
         "start_date": "2017-01-01T00:00:00Z",
         "user_agent": "email_address",

--- a/README.md
+++ b/README.md
@@ -34,9 +34,55 @@ Singer taps function in two modes: [discovery mode](https://github.com/singer-io
     }
     ```
 
-3. [Optional] Create the initial state file
+3. Run discover command and save catalog into catalog file
 
-    You can provide JSON file that contains a date for the metrics endpoints to force the application to only fetch events since those dates. If you omit the file it will fetch all
+    ```bash
+    tap-klaviyo --config config.json --discover > catalog.json
+    ```
+
+4. Select streams to sync in catalog.json file
+This [link](https://github.com/singer-io/getting-started/blob/master/docs/SYNC_MODE.md) explains the process of formatting catalog.json for stream selection (scroll to "Stream/Field Selection).
+
+*Option 1:* 
+To select a stream to sync, add {"breadcrumb": [], "metadata": {"selected": true}} to its "metadata" entry.
+
+The following example syncs the pipelines stream:
+
+...
+    "type": [
+      "null",
+      "object"
+    ],
+    "additionalProperties": false
+  },
+  "stream": "pipelines",
+  "metadata": [{"breadcrumb": [], "metadata": {"selected": true}}]
+},
+...
+
+*Option 2:*
+Add "selected": true to the stream's schema.
+
+...
+"tap_stream_id": "workflows",
+"key_properties": [],
+"schema": {
+  "selected": true,
+  "properties": {
+    "_pipeline_id": {
+      "type": [
+        "null",
+        "string"
+      ]
+...
+
+*Option 3:*
+You can use an [open-source tool called Singer Discover](https://github.com/chrisgoddard/singer-discover) to format the catalog.json file.
+    
+    
+5. [Optional] Create the initial state file
+
+    You can provide a JSON file that contains a date for the metrics endpoints to force the application to only fetch events since those dates. If you omit the file it will fetch all
     commits and issues.
 
     ```json
@@ -46,13 +92,7 @@ Singer taps function in two modes: [discovery mode](https://github.com/singer-io
     }
     ```
 
-4. [Optional] Run discover command and save catalog into catalog file
-
-    ```bash
-    tap-klaviyo --config config.json --discover > catalog.json
-    ```
-
-5. Run the application
+6. Run the application
 
     `tap-klaviyo` can be run with:
 
@@ -60,20 +100,11 @@ Singer taps function in two modes: [discovery mode](https://github.com/singer-io
     tap-klaviyo --config config.json [--state state.json] [--catalog catalog.json]
     ```
 
-
-
 ## Debugging
 
 If you have made changes to your repository, you may need to run the following command after navigating to your local repository (before running the tap):
 
     pip install -e .
-    
-
-## Formatting catalog.json
-You can format catalog.json to select which streams should be synced when the tap is run in sync mode. This [link](https://github.com/singer-io/getting-started/blob/master/docs/SYNC_MODE.md) explains the process of formatting catalog.json for stream selection (scroll to "Stream/Field Selection).
-
-You can also use an [open-source tool called Singer Discover](https://github.com/chrisgoddard/singer-discover) to format the catalog.json file.
-
 
 
 ---

--- a/tap_klaviyo/__init__.py
+++ b/tap_klaviyo/__init__.py
@@ -151,12 +151,11 @@ def main():
         do_discover(args.config['api_key'])
 
     else:
-        catalog = args.properties if args.properties else discover(
+        catalog = args.catalog.to_dict() if args.catalog else discover(
              args.config['api_key'])
 
         state = args.state if args.state else {"bookmarks": {}}
         do_sync(args.config, state, catalog)
-
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
# Description of change
This tap currently looks for "properties" -- as a result, to run the tap, you need to use "--properties" instead of "--catalog." This issue has been corrected so that the tap can be run using "--catalog."

Errors/typos in the readme and the example config.json file have also been corrected. The readme has also gained details that clarify the process of running the tap.

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
