### PR TITLE
TDL-684:Allowed fields to be selected via metadata

### DIFF
--- a/tap_klaviyo/__init__.py
+++ b/tap_klaviyo/__init__.py
@@ -38,20 +38,12 @@ class Stream(object):
 
     def to_catalog_dict(self):
         schema = load_schema(self.stream)
-
-        self.metadata.append({
-            'breadcrumb': (),
-            'metadata': {
-                'table-key-properties': self.key_properties,
-                'forced-replication-method': self.replication_method
-            }
-        })
-
-        for k in schema['properties']:
-            self.metadata.append({
-                'breadcrumb': ('properties', k),
-                'metadata': { 'inclusion': 'automatic' }
-            })
+        mdata = metadata.get_standard_metadata(
+            schema = schema,
+            key_properties = self.key_properties,
+            replication_method = self.replication_method
+        )
+        self.metadata = mdata
 
         return {
             'stream': self.stream,
@@ -141,7 +133,7 @@ def discover(api_key):
 
 
 def do_discover(api_key):
-    print(json.dumps(discover(api_key), sys.stdout, indent=2))
+    print(json.dumps(discover(api_key), indent=2))
 
 def main():
 

--- a/tap_klaviyo/__init__.py
+++ b/tap_klaviyo/__init__.py
@@ -38,12 +38,17 @@ class Stream(object):
 
     def to_catalog_dict(self):
         schema = load_schema(self.stream)
-        mdata = metadata.get_standard_metadata(
-            schema = schema,
-            key_properties = self.key_properties,
-            replication_method = self.replication_method
+        mdata = metadata.to_map(
+            metadata.get_standard_metadata(
+                schema = schema,
+                key_properties = self.key_properties,
+                replication_method = self.replication_method
+            )
         )
-        self.metadata = mdata
+
+        if self.replication_method == 'INCREMENTAL':
+            mdata = metadata.write(mdata, ('properties', 'timestamp'), 'inclusion', 'automatic')
+        self.metadata = metadata.to_list(mdata)
 
         return {
             'stream': self.stream,

--- a/tap_klaviyo/utils.py
+++ b/tap_klaviyo/utils.py
@@ -123,4 +123,3 @@ def transfrom_and_write_records(events, stream):
                 transformer.transform(
                     event, event_schema, event_mdata
             ))
-            

--- a/tap_klaviyo/utils.py
+++ b/tap_klaviyo/utils.py
@@ -123,3 +123,4 @@ def transfrom_and_write_records(events, stream):
                 transformer.transform(
                     event, event_schema, event_mdata
             ))
+            

--- a/tests/unittests/test_fields_inclusion_in_metadata.py
+++ b/tests/unittests/test_fields_inclusion_in_metadata.py
@@ -1,0 +1,52 @@
+import tap_klaviyo
+import unittest
+from unittest import mock
+from requests import Response
+import json
+
+
+def get_mock_http_response(status_code, contents):
+    contents = json.dumps(contents)
+    response = Response()
+    response.status_code = status_code
+    response._content = contents.encode()
+    return response
+
+
+class TestFieldsInclusionInMetadata(unittest.TestCase):
+    """
+    Test cases to verify inclusion value is available for fields in metadata and automatic for key_property
+    """
+    
+    @mock.patch("tap_klaviyo.get_all_pages")
+    def test_fields_inclusion_in_metadata(self, mock_get_all_pages):
+        api_key = "abc"
+        streams = [{"name": "Received Email", "id": "UfdfRD"},
+                   {"name": "Clicked Email", "id": "UrdfRD"},
+                   {"name": "Opened Email", "id": "UfdfRu"},
+                   {"name": "Bounced Email", "id": "RfdfRD"},
+                   {"name": "Unsubscribed", "id": "UddfRD"},
+                   {"name": "Marked Email as Spam", "id": "UffgbD"},
+                   {"name": "Unsubscribed from List", "id": "UsfewD"},
+                   {"name": "Subscribed to List", "id": "UrDfwD"},
+                   {"name": "Updated Email Preferences", "id": "AdfDfD"},
+                   {"name": "Dropped Email", "id": "AfdfdD"}]
+
+        mock_get_all_pages.return_value = [get_mock_http_response(
+            200, {"data": streams})]
+
+        # Get catalog
+        catalog = tap_klaviyo.discover(api_key)
+        catalog = catalog['streams']
+
+        for catalog_entry in catalog:
+            # Breadcrumbs of key_properties
+            key_prop_breadcrumbs = {('properties', x) for x in catalog_entry['key_properties']}
+
+            for field in catalog_entry['metadata']:
+                if field['breadcrumb'] in key_prop_breadcrumbs:
+                    # Verifying that all key properties are automatic inclusion
+                    self.assertEqual(field['metadata']['inclusion'], 'automatic')
+                else:
+                    # Verifying that all normal fields are available inclusion
+                    self.assertEqual(field['metadata']['inclusion'], 'available')


### PR DESCRIPTION
# Description of change
- Allowed fields to be selected via metadata.
- Added get_standard_metadata function to generate standard metadata.
- Added transformer to transform records from the Klaviyo API to ensure they conform to the schema and metadata.

# Manual QA steps
 - Manually checked catalog file for inclusion value of fields.
 - Selected some fields in the catalog file and verified state.json for records with selected fields.
 - Run unit test case to verifying the value of inclusion for all fields.
 
# Risks
 - No Risks Found
 
# Rollback steps
 - revert this branch
