### PR TITLE
Tdl 681 add retry mechanism

### DIFF
--- a/tap_klaviyo/__init__.py
+++ b/tap_klaviyo/__init__.py
@@ -141,7 +141,7 @@ def discover(api_key):
 
 
 def do_discover(api_key):
-    print(json.dumps(discover(api_key), sys.stdout, indent=2))
+    print(json.dumps(discover(api_key), indent=2))
 
 def main():
 

--- a/tap_klaviyo/utils.py
+++ b/tap_klaviyo/utils.py
@@ -41,7 +41,7 @@ ERROR_CODE_EXCEPTION_MAPPING = {
     },
     403: {
         "raise_exception": KlaviyoForbiddenError,
-        "message": "Request is missing or has an invalid API key."
+        "message": "Invalid authorization credentials or permissions."
     },
     404: {
         "raise_exception": KlaviyoNotFoundError,
@@ -49,7 +49,7 @@ ERROR_CODE_EXCEPTION_MAPPING = {
     },
     500: {
         "raise_exception": KlaviyoInternalServiceError,
-        "message": "Something is wrong on Klaviyo's end."
+        "message": "Internal Service Error from Klaviyo."
     }
 }
 

--- a/tests/test_backoff.py
+++ b/tests/test_backoff.py
@@ -1,0 +1,38 @@
+import tap_klaviyo.utils as utils_
+import unittest
+from unittest import mock
+import simplejson
+import singer
+from singer import metrics
+import json
+import requests
+
+class TestBackoff(unittest.TestCase):
+    
+    @mock.patch('requests.Session.request')
+    def test_httperror(self, mocked_session):
+
+        mock_resp = mock.Mock()
+        klaviyo_error = utils_.KlaviyoError()
+        mock_resp.raise_for_error.side_effect = klaviyo_error
+        mocked_session.return_value = mock_resp
+
+        try:
+            utils_.authed_get("", "", "")
+        except utils_.KlaviyoError:
+            pass
+
+        self.assertEquals(mocked_session.call_count, 3)
+
+    @mock.patch("tap_klaviyo.utils.get_all_pages")
+    def test_jsondecode(self, mock1):
+
+        mock1.return_value = ["abc"]
+
+        data = {'stream': 'lists'}
+        try:
+            utils_.get_full_pulls(data, "", "")
+        except simplejson.scanner.JSONDecodeError:
+            pass
+
+        self.assertEquals(mock1.call_count, 3)

--- a/tests/test_backoff.py
+++ b/tests/test_backoff.py
@@ -14,7 +14,11 @@ class TestBackoff(unittest.TestCase):
 
         mock_resp = mock.Mock()
         klaviyo_error = utils_.KlaviyoError()
+        http_error = requests.HTTPError()
+
         mock_resp.raise_for_error.side_effect = klaviyo_error
+        mock_resp.raise_for_status.side_effect = http_error
+        
         mocked_session.return_value = mock_resp
 
         try:
@@ -27,12 +31,12 @@ class TestBackoff(unittest.TestCase):
     @mock.patch("tap_klaviyo.utils.get_all_pages")
     def test_jsondecode(self, mock1):
 
-        mock1.return_value = ["abc"]
+        mock1.return_value = utils_.get_all_pages("lists", "http://www.youtube.com/results?bad+blood", "")
 
         data = {'stream': 'lists'}
         try:
-            utils_.get_full_pulls(data, "", "")
+            utils_.get_full_pulls(data, "http://www.youtube.com/results?abcd", "")
         except simplejson.scanner.JSONDecodeError:
             pass
 
-        self.assertEquals(mock1.call_count, 3)
+        self.assertEquals(mock1.call_count, 2)

--- a/tests/test_backoff.py
+++ b/tests/test_backoff.py
@@ -31,7 +31,7 @@ class TestBackoff(unittest.TestCase):
     @mock.patch("tap_klaviyo.utils.get_all_pages")
     def test_jsondecode(self, mock1):
 
-        mock1.return_value = utils_.get_all_pages("lists", "http://www.youtube.com/results?bad+blood", "")
+        mock1.return_value = utils_.get_all_pages("lists", "http://www.youtube.com/results?abcd", "")
 
         data = {'stream': 'lists'}
         try:

--- a/tests/test_exception_handling.py
+++ b/tests/test_exception_handling.py
@@ -6,7 +6,7 @@ import singer
 import json
 
 class Mockresponse:
-    def __init__(self, status_code, resp={}, content=None, headers=None, raise_error=False):
+    def __init__(self, status_code, resp=None, content=None, headers=None, raise_error=False):
         self.json_data = resp
         self.status_code = status_code
         self.content = content
@@ -92,7 +92,7 @@ class TestBackoff(unittest.TestCase):
         except utils_.KlaviyoError as e:
             with open("abc.txt", "w") as f:
                 f.write(str(e))
-            self.assertEquals(str(e), "HTTP-error-code: 403, Error: Request is missing or has an invalid API key.")
+            self.assertEquals(str(e), "HTTP-error-code: 403, Error: Invalid authorization credentials or permissions.")
 
     @mock.patch('requests.Session.request', side_effect=klaviyo_403_error_wrong_api_key)
     def test_403_error_wrong_api_key(self, klaviyo_403_error_wrong_api_key):
@@ -124,4 +124,4 @@ class TestBackoff(unittest.TestCase):
         try:
             utils_.authed_get("", "", "")
         except utils_.KlaviyoError as e:
-            self.assertEquals(str(e), "HTTP-error-code: 500, Error: Something is wrong on Klaviyo's end.")
+            self.assertEquals(str(e), "HTTP-error-code: 500, Error: Internal Service Error from Klaviyo.")

--- a/tests/test_exception_handling.py
+++ b/tests/test_exception_handling.py
@@ -1,0 +1,116 @@
+import tap_klaviyo.utils as utils_
+import unittest
+from unittest import mock
+import requests
+import singer
+
+class Mockresponse:
+    def __init__(self, resp, status_code, content=None, headers=None, raise_error=False):
+        self.json_data = resp
+        self.status_code = status_code
+        self.content = content
+        self.headers = headers
+        self.raise_error = raise_error
+    
+    def json(self):
+            return self.json_data
+
+def klaviyo_400_error(*args, **kwargs):
+    json_str = {}
+
+    return Mockresponse(json_str, 400, raise_error=True)
+
+def klaviyo_401_error(*args, **kwargs):
+    json_str = {}
+
+    return Mockresponse(json_str, 401, raise_error=True)
+
+def klaviyo_403_error(*args, **kwargs):
+    json_str = {}
+
+    return Mockresponse(json_str, 403, raise_error=True)
+
+def klaviyo_403_error_wrong_api_key(*args, **kwargs):
+    json_str = {
+    "status": 403,
+    "message": "The API key specified is invalid."}
+
+    return Mockresponse(json_str, 403, raise_error=True)
+
+def klaviyo_403_error_missing_api_key(*args, **kwargs):
+    json_str = {
+    "status": 403,
+    "message": "You must specify an API key to make requests."}
+
+    return Mockresponse(json_str, 403, raise_error=True)
+
+def klaviyo_404_error(*args, **kwargs):
+    json_str = {}
+
+    return Mockresponse(json_str, 404, raise_error=True)
+
+def klaviyo_500_error(*args, **kwargs):
+    json_str = {}
+
+    return Mockresponse(json_str, 500, raise_error=True)
+
+
+class TestBackoff(unittest.TestCase):
+    
+    @mock.patch('requests.Session.request', side_effect=klaviyo_400_error)
+    def test_400_error(self, klaviyo_400_error):
+
+        try:
+            utils_.authed_get("", "", "")
+        except utils_.KlaviyoError as e:
+            self.assertEquals(str(e), "HTTP-error-code: 400, Error: Request is missing or has a bad parameter.")
+
+    @mock.patch('requests.Session.request', side_effect=klaviyo_401_error)
+    def test_401_error(self, klaviyo_401_error):
+
+        try:
+            utils_.authed_get("", "", "")
+        except utils_.KlaviyoError as e:
+            self.assertEquals(str(e), "HTTP-error-code: 401, Error: Invalid authorization credentials.")
+
+    @mock.patch('requests.Session.request', side_effect=klaviyo_403_error)
+    def test_403_error(self, klaviyo_403_error):
+
+        try:
+            utils_.authed_get("", "", "")
+        except utils_.KlaviyoError as e:
+            with open("abc.txt", "w") as f:
+                f.write(str(e))
+            self.assertEquals(str(e), "HTTP-error-code: 403, Error: Request is missing or has an invalid API key.")
+
+    @mock.patch('requests.Session.request', side_effect=klaviyo_403_error_wrong_api_key)
+    def test_403_error_wrong_api_key(self, klaviyo_403_error_wrong_api_key):
+
+        try:
+            utils_.authed_get("", "", "")
+        except utils_.KlaviyoError as e:
+            self.assertEquals(str(e), "HTTP-error-code: 403, Error: The API key specified is invalid.")
+
+    @mock.patch('requests.Session.request', side_effect=klaviyo_403_error_missing_api_key)
+    def test_403_error_missing_api_key(self, klaviyo_403_error_missing_api_key):
+
+        try:
+            utils_.authed_get("", "", "")
+        except utils_.KlaviyoError as e:
+            self.assertEquals(str(e), "HTTP-error-code: 403, Error: You must specify an API key to make requests.")
+
+    @mock.patch('requests.Session.request', side_effect=klaviyo_404_error)
+    def test_404_error(self, klaviyo_404_error):
+
+        try:
+            utils_.authed_get("", "", "")
+        except utils_.KlaviyoError as e:
+            self.assertEquals(str(e), "HTTP-error-code: 404, Error: The requested resource doesn't exist.")
+
+    @mock.patch('requests.Session.request', side_effect=klaviyo_500_error)
+    def test_500_error(self, klaviyo_500_error):
+
+        try:
+            utils_.authed_get("", "", "")
+        except utils_.KlaviyoError as e:
+            self.assertEquals(str(e), "HTTP-error-code: 500, Error: Something is wrong on Klaviyo's end.")


### PR DESCRIPTION
# Description of change
- TDL-681: HTTP requests that fail are not retrying - Added retry mechanism for requests that are failing
- Added exception handling ie. KlaviyoError

# Manual QA steps
- Manually raised KlaviyoError and JSONDecoder error and checked retrying of requests
- Test Cases that checks the retrying of requests on error
- Test Cases for checking exception handling and error message
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
