### PR TITLE
TDL-15259 Add standard replication test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
           name: 'Pylint'
           command: |
             source ~/.virtualenvs/tap-klaviyo/bin/activate
-            pylint tap_klaviyo -d C,R
+            pylint tap_klaviyo -d C,R,'unspecified-encoding'
       - run:
           name: 'Unit Tests'
           command: |

--- a/tests/base.py
+++ b/tests/base.py
@@ -20,6 +20,7 @@ class KlaviyoBaseTest(unittest.TestCase):
     INCREMENTAL = "INCREMENTAL"
     FULL_TABLE = "FULL_TABLE"
     BOOKMARK = "bookmark"
+    REPLICATION_KEYS = "REPLICATION_KEYS"
     START_DATE_FORMAT = "%Y-%m-%dT00:00:00Z"
     DATETIME_FMT = "%Y-%m-%dT%H:%M:%SZ"
     start_date = ""
@@ -61,55 +62,67 @@ class KlaviyoBaseTest(unittest.TestCase):
 
     def expected_metadata(self):
         """The expected primary key of the streams"""
+        # Added new REPLICATION_KEYS field as all incremental streams save the bookmark in `since` 
+        # field which is different from the bookmark key.
         return{
             "receive": {
                 self.PRIMARY_KEYS: {"id"},
                 self.REPLICATION_METHOD: self.INCREMENTAL,
+                self.REPLICATION_KEYS:{"since"},
                 self.BOOKMARK: {"timestamp"}
             },
             "click": {
                 self.PRIMARY_KEYS: {"id"},
                 self.REPLICATION_METHOD: self.INCREMENTAL,
+                self.REPLICATION_KEYS:{"since"},
                 self.BOOKMARK: {"timestamp"}
             },
             "open": {
                 self.PRIMARY_KEYS: {"id"},
                 self.REPLICATION_METHOD: self.INCREMENTAL,
+                self.REPLICATION_KEYS:{"since"},
                 self.BOOKMARK: {"timestamp"}
             },
             "bounce": {
                 self.PRIMARY_KEYS: {"id"},
                 self.REPLICATION_METHOD: self.INCREMENTAL,
+                self.REPLICATION_KEYS:{"since"},
                 self.BOOKMARK: {"timestamp"}
             },
             "unsubscribe": {
                 self.PRIMARY_KEYS: {"id"},
                 self.REPLICATION_METHOD: self.INCREMENTAL,
+                self.REPLICATION_KEYS:{"since"},
                 self.BOOKMARK: {"timestamp"}
             },
             "mark_as_spam": {
                 self.PRIMARY_KEYS: {"id"},
                 self.REPLICATION_METHOD: self.INCREMENTAL,
+                self.REPLICATION_KEYS:{"since"},
                 self.BOOKMARK: {"timestamp"}
             },
             "dropped_email": {
                 self.PRIMARY_KEYS: {"id"},
                 self.REPLICATION_METHOD: self.INCREMENTAL,
+                self.REPLICATION_KEYS:{"since"},
                 self.BOOKMARK: {"timestamp"}
             },
             "unsub_list": {
                 self.PRIMARY_KEYS: {"id"},
                 self.REPLICATION_METHOD: self.INCREMENTAL,
+                self.REPLICATION_KEYS:{"since"},
                 self.BOOKMARK: {"timestamp"}
             },
             "subscribe_list": {
                 self.PRIMARY_KEYS: {"id"},
                 self.REPLICATION_METHOD: self.INCREMENTAL,
+                self.REPLICATION_KEYS:{"since"},
                 self.BOOKMARK: {"timestamp"}
             },
             "update_email_preferences": {
                 self.PRIMARY_KEYS: {"id"},
                 self.REPLICATION_METHOD: self.INCREMENTAL,
+                self.REPLICATION_KEYS:{"since"},
                 self.BOOKMARK: {"timestamp"}
             },
             "global_exclusions": {
@@ -139,6 +152,12 @@ class KlaviyoBaseTest(unittest.TestCase):
     def expected_bookmark_keys(self):
         """return a dictionary with key of table name and value as a set of bookmark key fields"""
         return {table: properties.get(self.BOOKMARK, set())
+                for table, properties
+                in self.expected_metadata().items()}
+
+    def expected_replication_keys(self):
+        """return a dictionary with key of table name and value as a set of replication key fields"""
+        return {table: properties.get(self.REPLICATION_KEYS, set())
                 for table, properties
                 in self.expected_metadata().items()}
 

--- a/tests/test_klaviyo_bookmark.py
+++ b/tests/test_klaviyo_bookmark.py
@@ -28,9 +28,8 @@ class BookmarkTest(KlaviyoBaseTest):
             different values for the replication key
         """
         
-        expected_streams = self.expected_streams()
         # We are not able to generate test data so skipping two streams(mark_as_spam, dropped_email)
-        expected_streams = expected_streams - {"mark_as_spam", "dropped_email"}
+        expected_streams = self.expected_streams() - {"mark_as_spam", "dropped_email"}
         
         expected_bookmark_keys = self.expected_bookmark_keys()
         expected_replication_methods = self.expected_replication_method()

--- a/tests/test_klaviyo_bookmark.py
+++ b/tests/test_klaviyo_bookmark.py
@@ -29,6 +29,9 @@ class BookmarkTest(KlaviyoBaseTest):
         """
         
         expected_streams = self.expected_streams()
+        # We are not able to generate test data so skipping two streams(mark_as_spam, dropped_email)
+        expected_streams = expected_streams - {"mark_as_spam", "dropped_email"}
+        
         expected_bookmark_keys = self.expected_bookmark_keys()
         expected_replication_methods = self.expected_replication_method()
         
@@ -76,12 +79,7 @@ class BookmarkTest(KlaviyoBaseTest):
         ##########################################################################
 
 
-        for stream in expected_streams:
-            
-            # WE ARE NOT ABLE TO GENERATE TEST DATA SO SKIPPING TWO STREAMS(mark_as_spam, dropped_email)
-            if stream in ["mark_as_spam", "dropped_email"]:
-                continue
-            
+        for stream in expected_streams:            
             with self.subTest(stream=stream):
 
                 # expected values

--- a/tests/test_klaviyo_bookmark.py
+++ b/tests/test_klaviyo_bookmark.py
@@ -1,0 +1,177 @@
+from tap_tester import menagerie
+
+from tap_tester import connections, runner
+from base import KlaviyoBaseTest
+
+class BookmarkTest(KlaviyoBaseTest):
+    """Test tap sets a bookmark and respects it for the next sync of a stream"""
+
+    @staticmethod
+    def name():
+        return "tap_tester_klaviyo_bookmark_test"
+    
+    def test_run(self):
+        """
+        Verify that for each stream you can do a sync which records bookmarks.
+        That the bookmark is the maximum value sent to the target for the replication key.
+        That a second sync respects the bookmark
+            All data of the second sync is >= the bookmark from the first sync
+            The number of records in the 2nd sync is less then the first (This assumes that
+                new data added to the stream is done at a rate slow enough that you haven't
+                doubled the amount of data from the start date to the first sync between
+                the first sync and second sync run in this test)
+
+        Verify that for full table stream, all data replicated in sync 1 is replicated again in sync 2.
+
+        PREREQUISITE
+        For EACH stream that is incrementally replicated there are multiple rows of data with
+            different values for the replication key
+        """
+        
+        expected_streams = self.expected_streams()
+        expected_bookmark_keys = self.expected_bookmark_keys()
+        expected_replication_methods = self.expected_replication_method()
+        
+        ##########################################################################
+        # First Sync
+        ##########################################################################
+        conn_id = connections.ensure_connection(self)
+
+        # Run in check mode
+        found_catalogs = self.run_and_verify_check_mode(conn_id)
+
+        # table and field selection
+        catalog_entries = [catalog for catalog in found_catalogs
+                            if catalog.get('tap_stream_id') in expected_streams]
+
+        self.perform_and_verify_table_and_field_selection(
+            conn_id, found_catalogs)
+
+        # Run a first sync job using orchestrator
+        first_sync_record_count = self.run_and_verify_sync(conn_id)
+        first_sync_records = runner.get_records_from_target_output()
+        first_sync_bookmarks = menagerie.get_state(conn_id)
+
+        ##########################################################################
+        # Update State Between Syncs
+        ##########################################################################
+
+        new_states = {'bookmarks': dict()}
+        simulated_states = self.calculated_states_by_stream(
+            first_sync_bookmarks)
+        for stream, new_state in simulated_states.items():
+            new_states['bookmarks'][stream] = new_state
+        menagerie.set_state(conn_id, new_states)
+
+        ##########################################################################
+        # Second Sync
+        ##########################################################################
+
+        second_sync_record_count = self.run_and_verify_sync(conn_id)
+        second_sync_records = runner.get_records_from_target_output()
+        second_sync_bookmarks = menagerie.get_state(conn_id)
+
+        ##########################################################################
+        # Test By Stream
+        ##########################################################################
+
+
+        for stream in expected_streams:
+            
+            # WE ARE NOT ABLE TO GENERATE TEST DATA SO SKIPPING TWO STREAMS(mark_as_spam, dropped_email)
+            if stream in ["mark_as_spam", "dropped_email"]:
+                continue
+            
+            with self.subTest(stream=stream):
+
+                # expected values
+                expected_replication_method = expected_replication_methods[stream]
+
+                # collect information for assertions from syncs 1 & 2 base on expected values
+                first_sync_count = first_sync_record_count.get(stream, 0)
+                second_sync_count = second_sync_record_count.get(stream, 0)
+                first_sync_messages = [record.get('data') for record in
+                                       first_sync_records.get(
+                                           stream, {}).get('messages', [])
+                                       if record.get('action') == 'upsert']
+                second_sync_messages = [record.get('data') for record in
+                                        second_sync_records.get(
+                                            stream, {}).get('messages', [])
+                                        if record.get('action') == 'upsert']
+                first_bookmark_key_value = first_sync_bookmarks.get('bookmarks', {stream: None}).get(stream)
+                second_bookmark_key_value = second_sync_bookmarks.get('bookmarks', {stream: None}).get(stream)
+                
+
+                if expected_replication_method == self.INCREMENTAL:
+
+                    # collect information specific to incremental streams from syncs 1 & 2
+                    replication_key = 'since' #As in it writes bookmark in key 'since' for all stream
+                    record_replication_key = list(expected_bookmark_keys[stream])[0]
+
+                    first_bookmark_value = first_bookmark_key_value.get(replication_key)
+                    second_bookmark_value = second_bookmark_key_value.get(replication_key)
+                    
+                    first_bookmark_value_ts = self.dt_to_ts(first_bookmark_value)
+                    
+                    second_bookmark_value_ts = self.dt_to_ts(second_bookmark_value)
+                    
+                    simulated_bookmark_value = self.dt_to_ts(new_states['bookmarks'][stream][replication_key])
+
+                    # Verify the first sync sets a bookmark of the expected form
+                    self.assertIsNotNone(first_bookmark_key_value)
+                    self.assertIsNotNone(first_bookmark_value)
+                    
+                    self.assertIsNotNone(second_bookmark_key_value)
+                    self.assertIsNotNone(second_bookmark_value)
+
+                    # Verify the second sync bookmark is Equal to the first sync bookmark
+                    # assumes no changes to data during test
+                    self.assertEqual(second_bookmark_value,
+                                     first_bookmark_value)
+                    
+                    for record in first_sync_messages:
+
+                        # Verify the first sync bookmark value is the max replication key value for a given stream
+                        replication_key_value = record.get(record_replication_key)
+                        self.assertLessEqual(
+                            replication_key_value, first_bookmark_value_ts,
+                            msg="First sync bookmark was set incorrectly, a record with a greater replication-key value was synced."
+                        )
+
+                    for record in second_sync_messages:
+                        # Verify the second sync replication key value is Greater or Equal to the first sync bookmark
+                        replication_key_value = record.get(record_replication_key)
+                        self.assertGreaterEqual(replication_key_value, simulated_bookmark_value,
+                                                msg="Second sync records do not repect the previous bookmark.")
+
+                        # Verify the second sync bookmark value is the max replication key value for a given stream
+                        self.assertLessEqual(
+                            replication_key_value, second_bookmark_value_ts,
+                            msg="Second sync bookmark was set incorrectly, a record with a greater replication-key value was synced."
+                        )
+
+                    # verify that you get less data the 2nd time around
+                    self.assertLess(
+                        second_sync_count,
+                        first_sync_count,
+                        msg="second sync didn't have less records, bookmark usage not verified")
+
+                elif expected_replication_method == self.FULL_TABLE:
+
+                    # Verify the syncs do not set a bookmark for full table streams
+                    self.assertIsNone(first_bookmark_key_value)
+                    self.assertIsNone(second_bookmark_key_value)
+
+                    # Verify the number of records in the second sync is the same as the first
+                    self.assertEqual(second_sync_count, first_sync_count)
+
+                else:
+
+                    raise NotImplementedError(
+                        "INVALID EXPECTATIONS\t\tSTREAM: {} REPLICATION_METHOD: {}".format(
+                            stream, expected_replication_method)
+                    )
+
+                # Verify at least 1 record was replicated in the second sync
+                self.assertGreater(
+                    second_sync_count, 0, msg="We are not fully testing bookmarking for {}".format(stream))

--- a/tests/test_klaviyo_bookmark.py
+++ b/tests/test_klaviyo_bookmark.py
@@ -32,6 +32,7 @@ class BookmarkTest(KlaviyoBaseTest):
         expected_streams = self.expected_streams() - {"mark_as_spam", "dropped_email"}
         
         expected_bookmark_keys = self.expected_bookmark_keys()
+        expected_replication_keys = self.expected_replication_keys()
         expected_replication_methods = self.expected_replication_method()
         
         ##########################################################################
@@ -102,7 +103,7 @@ class BookmarkTest(KlaviyoBaseTest):
                 if expected_replication_method == self.INCREMENTAL:
 
                     # collect information specific to incremental streams from syncs 1 & 2
-                    replication_key = 'since' #As in it writes bookmark in key 'since' for all stream
+                    replication_key = list(expected_replication_keys[stream])[0] #Key in which state has been saved in state file
                     record_replication_key = list(expected_bookmark_keys[stream])[0]
 
                     first_bookmark_value = first_bookmark_key_value.get(replication_key)


### PR DESCRIPTION
# Description of change
TDL-15259 Add standard replication test
- A standard bookmark test is added to the tap-tester suite

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
