### PR TITLE
TDL-18804 Updated backoff error handling

### DIFF
--- a/tap_klaviyo/utils.py
+++ b/tap_klaviyo/utils.py
@@ -72,7 +72,7 @@ ERROR_CODE_EXCEPTION_MAPPING = {
     },
     429: {
         "raise_exception": KlaviyoRateLimitError,
-        "message": "The API rate limit for your organisation/application pairing has been exceeded."
+        "message": "The API rate limit for your organization/application pairing has been exceeded."
     },
     500: {
         "raise_exception": KlaviyoInternalServiceError,

--- a/tap_klaviyo/utils.py
+++ b/tap_klaviyo/utils.py
@@ -96,7 +96,7 @@ ERROR_CODE_EXCEPTION_MAPPING = {
     },
     524: {
         "raise_exception": KlaviyoServerTimeoutError,
-        "message": "Server server took too long to respond to the request."
+        "message": "Server took too long to respond to the request."
     },
 }
 

--- a/tap_klaviyo/utils.py
+++ b/tap_klaviyo/utils.py
@@ -32,6 +32,9 @@ class KlaviyoUnauthorizedError(KlaviyoError):
 class KlaviyoForbiddenError(KlaviyoError):
     pass
 
+class KlaviyoConflictError(KlaviyoError):
+    pass
+
 class KlaviyoRateLimitError(KlaviyoBackoffError):
     pass
 
@@ -69,6 +72,10 @@ ERROR_CODE_EXCEPTION_MAPPING = {
     404: {
         "raise_exception": KlaviyoNotFoundError,
         "message": "The requested resource doesn't exist."
+    },
+    409: {
+        "raise_exception": KlaviyoConflictError,
+        "message": "The API request cannot be completed because the requested operation would conflict with an existing item."
     },
     429: {
         "raise_exception": KlaviyoRateLimitError,

--- a/tests/unittests/test_backoff.py
+++ b/tests/unittests/test_backoff.py
@@ -146,7 +146,7 @@ class TestBackoff(unittest.TestCase):
         # verify that we backoff for 3 times
         self.assertEquals(mocked_session.call_count, 3)
 
-    def test_server_timeout_perror(self, mocked_session, mocked_get_request_timeout, mocked_sleep):
+    def test_server_timeout_error(self, mocked_session, mocked_get_request_timeout, mocked_sleep):
         """
         Check whether the request backoffs properly for authed_get() for 5 times in case of KlaviyoServerTimeoutError.
         """
@@ -164,6 +164,30 @@ class TestBackoff(unittest.TestCase):
         try:
             utils_.authed_get("", "", "")
         except utils_.KlaviyoServerTimeoutError:
+            pass
+
+        # verify that we backoff for 3 times
+        self.assertEquals(mocked_session.call_count, 3)
+    
+
+    def test_rate_limit_error(self, mocked_session, mocked_get_request_timeout, mocked_sleep):
+        """
+        Check whether the request backoffs properly for authed_get() for 5 times in case of KlaviyoRateLimitError.
+        """
+        mock_resp = mock.Mock()
+        
+        klaviyo_error = utils_.KlaviyoRateLimitError()
+        http_error = requests.HTTPError()
+
+        mock_resp.raise_for_error.side_effect = klaviyo_error
+        mock_resp.raise_for_status.side_effect = http_error
+        mock_resp.status_code = 429
+        
+        mocked_session.return_value = mock_resp
+
+        try:
+            utils_.authed_get("", "", "")
+        except utils_.KlaviyoRateLimitError:
             pass
 
         # verify that we backoff for 3 times

--- a/tests/unittests/test_backoff.py
+++ b/tests/unittests/test_backoff.py
@@ -14,7 +14,7 @@ class TestBackoff(unittest.TestCase):
     
     def test_internal_service_error(self, mocked_session, mocked_get_request_timeout, mocked_sleep):
         """
-        Check whether the request backoffs properly for authed_get() for 5 times in case of KlaviyoInternalServiceError.
+        Check whether the request backoffs properly for authed_get() for 3 times in case of KlaviyoInternalServiceError.
         """
         mock_resp = mock.Mock()
         
@@ -37,7 +37,7 @@ class TestBackoff(unittest.TestCase):
 
     def test_jsondecode(self, mocked_request, mocked_get_request_timeout, mocked_sleep):
         """
-        Check whether the request backoffs properly for authed_get() for 5 times in case of JSONDecodeError.
+        Check whether the request backoffs properly for authed_get() for 3 times in case of JSONDecodeError.
         """
         mock_resp = mock.Mock()
 
@@ -56,7 +56,7 @@ class TestBackoff(unittest.TestCase):
 
     def test_not_implemented_error(self, mocked_session, mocked_get_request_timeout, mocked_sleep):
         """
-        Check whether the request backoffs properly for authed_get() for 5 times in case of KlaviyoNotImplementedError.
+        Check whether the request backoffs properly for authed_get() for 3 times in case of KlaviyoNotImplementedError.
         """
         mock_resp = mock.Mock()
         
@@ -79,7 +79,7 @@ class TestBackoff(unittest.TestCase):
 
     def test_bad_gateway_error(self, mocked_session, mocked_get_request_timeout, mocked_sleep):
         """
-        Check whether the request backoffs properly for authed_get() for 5 times in case of KlaviyoBadGatewayError.
+        Check whether the request backoffs properly for authed_get() for 3 times in case of KlaviyoBadGatewayError.
         """
         mock_resp = mock.Mock()
         
@@ -102,7 +102,7 @@ class TestBackoff(unittest.TestCase):
 
     def test_service_unavailable_error(self, mocked_session, mocked_get_request_timeout, mocked_sleep):
         """
-        Check whether the request backoffs properly for authed_get() for 5 times in case of KlaviyoServiceUnavailableError.
+        Check whether the request backoffs properly for authed_get() for 3 times in case of KlaviyoServiceUnavailableError.
         """
         mock_resp = mock.Mock()
         
@@ -125,7 +125,7 @@ class TestBackoff(unittest.TestCase):
 
     def test_gateway_timeout_error(self, mocked_session, mocked_get_request_timeout, mocked_sleep):
         """
-        Check whether the request backoffs properly for authed_get() for 5 times in case of KlaviyoGatewayTimeoutError.
+        Check whether the request backoffs properly for authed_get() for 3 times in case of KlaviyoGatewayTimeoutError.
         """
         mock_resp = mock.Mock()
         
@@ -148,7 +148,7 @@ class TestBackoff(unittest.TestCase):
 
     def test_server_timeout_error(self, mocked_session, mocked_get_request_timeout, mocked_sleep):
         """
-        Check whether the request backoffs properly for authed_get() for 5 times in case of KlaviyoServerTimeoutError.
+        Check whether the request backoffs properly for authed_get() for 3 times in case of KlaviyoServerTimeoutError.
         """
         mock_resp = mock.Mock()
         
@@ -172,7 +172,7 @@ class TestBackoff(unittest.TestCase):
 
     def test_rate_limit_error(self, mocked_session, mocked_get_request_timeout, mocked_sleep):
         """
-        Check whether the request backoffs properly for authed_get() for 5 times in case of KlaviyoRateLimitError.
+        Check whether the request backoffs properly for authed_get() for 3 times in case of KlaviyoRateLimitError.
         """
         mock_resp = mock.Mock()
         

--- a/tests/unittests/test_backoff.py
+++ b/tests/unittests/test_backoff.py
@@ -7,12 +7,15 @@ from singer import metrics
 import json
 import requests
 
+@mock.patch('time.sleep')
 @mock.patch("tap_klaviyo.utils.get_request_timeout")
+@mock.patch('requests.Session.request')
 class TestBackoff(unittest.TestCase):
     
-    @mock.patch('requests.Session.request')
-    def test_httperror(self, mocked_session, mocked_get_request_timeout):
-
+    def test_internal_service_error(self, mocked_session, mocked_get_request_timeout, mocked_sleep):
+        """
+        Check whether the request backoffs properly for authed_get() for 5 times in case of KlaviyoInternalServiceError.
+        """
         mock_resp = mock.Mock()
         
         klaviyo_error = utils_.KlaviyoInternalServiceError()
@@ -29,11 +32,13 @@ class TestBackoff(unittest.TestCase):
         except utils_.KlaviyoInternalServiceError:
             pass
 
+        # verify that we backoff for 3 times
         self.assertEquals(mocked_session.call_count, 3)
 
-    @mock.patch("requests.Session.request")
-    def test_jsondecode(self, mocked_request, mocked_get_request_timeout):
-
+    def test_jsondecode(self, mocked_request, mocked_get_request_timeout, mocked_sleep):
+        """
+        Check whether the request backoffs properly for authed_get() for 5 times in case of JSONDecodeError.
+        """
         mock_resp = mock.Mock()
 
         mock_resp.status_code = 200
@@ -46,4 +51,120 @@ class TestBackoff(unittest.TestCase):
         except simplejson.scanner.JSONDecodeError:
             pass
 
+        # verify that we backoff for 3 times
         self.assertEquals(mocked_request.call_count, 3)
+
+    def test_not_implemented_error(self, mocked_session, mocked_get_request_timeout, mocked_sleep):
+        """
+        Check whether the request backoffs properly for authed_get() for 5 times in case of KlaviyoNotImplementedError.
+        """
+        mock_resp = mock.Mock()
+        
+        klaviyo_error = utils_.KlaviyoNotImplementedError()
+        http_error = requests.HTTPError()
+
+        mock_resp.raise_for_error.side_effect = klaviyo_error
+        mock_resp.raise_for_status.side_effect = http_error
+        mock_resp.status_code = 501
+        
+        mocked_session.return_value = mock_resp
+
+        try:
+            utils_.authed_get("", "", "")
+        except utils_.KlaviyoNotImplementedError:
+            pass
+        
+        # verify that we backoff for 3 times
+        self.assertEquals(mocked_session.call_count, 3)
+
+    def test_bad_gateway_error(self, mocked_session, mocked_get_request_timeout, mocked_sleep):
+        """
+        Check whether the request backoffs properly for authed_get() for 5 times in case of KlaviyoBadGatewayError.
+        """
+        mock_resp = mock.Mock()
+        
+        klaviyo_error = utils_.KlaviyoBadGatewayError()
+        http_error = requests.HTTPError()
+
+        mock_resp.raise_for_error.side_effect = klaviyo_error
+        mock_resp.raise_for_status.side_effect = http_error
+        mock_resp.status_code = 502
+        
+        mocked_session.return_value = mock_resp
+
+        try:
+            utils_.authed_get("", "", "")
+        except utils_.KlaviyoBadGatewayError:
+            pass
+
+        # verify that we backoff for 3 times
+        self.assertEquals(mocked_session.call_count, 3)
+
+    def test_service_unavailable_error(self, mocked_session, mocked_get_request_timeout, mocked_sleep):
+        """
+        Check whether the request backoffs properly for authed_get() for 5 times in case of KlaviyoServiceUnavailableError.
+        """
+        mock_resp = mock.Mock()
+        
+        klaviyo_error = utils_.KlaviyoServiceUnavailableError()
+        http_error = requests.HTTPError()
+
+        mock_resp.raise_for_error.side_effect = klaviyo_error
+        mock_resp.raise_for_status.side_effect = http_error
+        mock_resp.status_code = 503
+        
+        mocked_session.return_value = mock_resp
+
+        try:
+            utils_.authed_get("", "", "")
+        except utils_.KlaviyoServiceUnavailableError:
+            pass
+
+        # verify that we backoff for 3 times
+        self.assertEquals(mocked_session.call_count, 3)
+
+    def test_gateway_timeout_error(self, mocked_session, mocked_get_request_timeout, mocked_sleep):
+        """
+        Check whether the request backoffs properly for authed_get() for 5 times in case of KlaviyoGatewayTimeoutError.
+        """
+        mock_resp = mock.Mock()
+        
+        klaviyo_error = utils_.KlaviyoGatewayTimeoutError()
+        http_error = requests.HTTPError()
+
+        mock_resp.raise_for_error.side_effect = klaviyo_error
+        mock_resp.raise_for_status.side_effect = http_error
+        mock_resp.status_code = 504
+        
+        mocked_session.return_value = mock_resp
+
+        try:
+            utils_.authed_get("", "", "")
+        except utils_.KlaviyoGatewayTimeoutError:
+            pass
+
+        # verify that we backoff for 3 times
+        self.assertEquals(mocked_session.call_count, 3)
+
+    def test_server_timeout_perror(self, mocked_session, mocked_get_request_timeout, mocked_sleep):
+        """
+        Check whether the request backoffs properly for authed_get() for 5 times in case of KlaviyoServerTimeoutError.
+        """
+        mock_resp = mock.Mock()
+        
+        klaviyo_error = utils_.KlaviyoServerTimeoutError()
+        http_error = requests.HTTPError()
+
+        mock_resp.raise_for_error.side_effect = klaviyo_error
+        mock_resp.raise_for_status.side_effect = http_error
+        mock_resp.status_code = 524
+        
+        mocked_session.return_value = mock_resp
+
+        try:
+            utils_.authed_get("", "", "")
+        except utils_.KlaviyoServerTimeoutError:
+            pass
+
+        # verify that we backoff for 3 times
+        self.assertEquals(mocked_session.call_count, 3)

--- a/tests/unittests/test_exception_handling.py
+++ b/tests/unittests/test_exception_handling.py
@@ -58,6 +58,25 @@ def klaviyo_500_error(*args, **kwargs):
 
     return Mockresponse(status_code=500, raise_error=True)
 
+def klaviyo_501_error(*args, **kwargs):
+
+    return Mockresponse(status_code=501, raise_error=True)
+
+def klaviyo_502_error(*args, **kwargs):
+
+    return Mockresponse(status_code=502, raise_error=True)
+
+def klaviyo_503_error(*args, **kwargs):
+
+    return Mockresponse(status_code=503, raise_error=True)
+
+def klaviyo_504_error(*args, **kwargs):
+
+    return Mockresponse(status_code=504, raise_error=True)
+
+def klaviyo_524_error(*args, **kwargs):
+
+    return Mockresponse(status_code=524, raise_error=True)
 
 @mock.patch("tap_klaviyo.utils.get_request_timeout")
 class TestBackoff(unittest.TestCase):
@@ -71,7 +90,9 @@ class TestBackoff(unittest.TestCase):
     
     @mock.patch('requests.Session.request', side_effect=klaviyo_400_error)
     def test_400_error(self, klaviyo_400_error, mocked_get_request_timeout):
-
+        """
+        Test that `authed_get` raise 400 error with proper message
+        """
         try:
             utils_.authed_get("", "", "")
         except utils_.KlaviyoBadRequestError as e:
@@ -79,7 +100,9 @@ class TestBackoff(unittest.TestCase):
 
     @mock.patch('requests.Session.request', side_effect=klaviyo_401_error)
     def test_401_error(self, klaviyo_401_error, mocked_get_request_timeout):
-
+        """
+        Test that `authed_get` raise 401 error with proper message
+        """
         try:
             utils_.authed_get("", "", "")
         except utils_.KlaviyoUnauthorizedError as e:
@@ -87,7 +110,9 @@ class TestBackoff(unittest.TestCase):
 
     @mock.patch('requests.Session.request', side_effect=klaviyo_403_error)
     def test_403_error(self, klaviyo_403_error, mocked_get_request_timeout):
-
+        """
+        Test that `authed_get` raise 403 error with proper message
+        """
         try:
             utils_.authed_get("", "", "")
         except utils_.KlaviyoForbiddenError as e:
@@ -95,7 +120,9 @@ class TestBackoff(unittest.TestCase):
 
     @mock.patch('requests.Session.request', side_effect=klaviyo_403_error_wrong_api_key)
     def test_403_error_wrong_api_key(self, klaviyo_403_error_wrong_api_key, mocked_get_request_timeout):
-
+        """
+        Test that `authed_get` raise 403 error with proper message for wrong api key
+        """
         try:
             utils_.authed_get("", "", "")
         except utils_.KlaviyoForbiddenError as e:
@@ -103,7 +130,9 @@ class TestBackoff(unittest.TestCase):
 
     @mock.patch('requests.Session.request', side_effect=klaviyo_403_error_missing_api_key)
     def test_403_error_missing_api_key(self, klaviyo_403_error_missing_api_key, mocked_get_request_timeout):
-
+        """
+        Test that `authed_get` raise 403 error with proper message for empty api key
+        """
         try:
             utils_.authed_get("", "", "")
         except utils_.KlaviyoForbiddenError as e:
@@ -111,16 +140,76 @@ class TestBackoff(unittest.TestCase):
 
     @mock.patch('requests.Session.request', side_effect=klaviyo_404_error)
     def test_404_error(self, klaviyo_404_error, mocked_get_request_timeout):
-
+        """
+        Test that `authed_get` raise 404 error with proper message
+        """
         try:
             utils_.authed_get("", "", "")
         except utils_.KlaviyoNotFoundError as e:
             self.assertEquals(str(e), "HTTP-error-code: 404, Error: The requested resource doesn't exist.")
 
+    @mock.patch('time.sleep')
     @mock.patch('requests.Session.request', side_effect=klaviyo_500_error)
-    def test_500_error(self, klaviyo_500_error, mocked_get_request_timeout):
-
+    def test_500_error(self, klaviyo_500_error, mocked_sleep, mocked_get_request_timeout):
+        """
+        Test that `authed_get` raise 500 error with proper message
+        """
         try:
             utils_.authed_get("", "", "")
         except utils_.KlaviyoInternalServiceError as e:
             self.assertEquals(str(e), "HTTP-error-code: 500, Error: Internal Service Error from Klaviyo.")
+
+    @mock.patch('time.sleep')
+    @mock.patch('requests.Session.request', side_effect=klaviyo_501_error)
+    def test_501_error(self, klaviyo_501_error, mocked_sleep, mocked_get_request_timeout):
+        """
+        Test that `authed_get` raise 501 error with proper message
+        """
+        try:
+            utils_.authed_get("", "", "")
+        except utils_.KlaviyoNotImplementedError as e:
+            self.assertEquals(str(e), "HTTP-error-code: 501, Error: The server does not support the functionality required to fulfill the request.")
+
+    @mock.patch('time.sleep')
+    @mock.patch('requests.Session.request', side_effect=klaviyo_502_error)
+    def test_502_error(self, klaviyo_502_error, mocked_sleep, mocked_get_request_timeout):
+        """
+        Test that `authed_get` raise 502 error with proper message
+        """
+        try:
+            utils_.authed_get("", "", "")
+        except utils_.KlaviyoBadGatewayError as e:
+            self.assertEquals(str(e), "HTTP-error-code: 502, Error: Server received an invalid response from another server.")
+
+    @mock.patch('time.sleep')
+    @mock.patch('requests.Session.request', side_effect=klaviyo_503_error)
+    def test_503_error(self, klaviyo_503_error, mocked_sleep, mocked_get_request_timeout):
+        """
+        Test that `authed_get` raise 503 error with proper message
+        """
+        try:
+            utils_.authed_get("", "", "")
+        except utils_.KlaviyoServiceUnavailableError as e:
+            self.assertEquals(str(e), "HTTP-error-code: 503, Error: API service is currently unavailable.")
+
+    @mock.patch('time.sleep')
+    @mock.patch('requests.Session.request', side_effect=klaviyo_504_error)
+    def test_504_error(self, klaviyo_504_error, mocked_sleep, mocked_get_request_timeout):
+        """
+        Test that `authed_get` raise 504 error with proper message
+        """
+        try:
+            utils_.authed_get("", "", "")
+        except utils_.KlaviyoGatewayTimeoutError as e:
+            self.assertEquals(str(e), "HTTP-error-code: 504, Error: Server did not return a response from another server.")
+
+    @mock.patch('time.sleep')
+    @mock.patch('requests.Session.request', side_effect=klaviyo_524_error)
+    def test_524_error(self, klaviyo_524_error, mocked_sleep, mocked_get_request_timeout):
+        """
+        Test that `authed_get` raise 524 error with proper message
+        """
+        try:
+            utils_.authed_get("", "", "")
+        except utils_.KlaviyoServerTimeoutError as e:
+            self.assertEquals(str(e), "HTTP-error-code: 524, Error: Server server took too long to respond to the request.")

--- a/tests/unittests/test_exception_handling.py
+++ b/tests/unittests/test_exception_handling.py
@@ -58,6 +58,10 @@ def klaviyo_500_error(*args, **kwargs):
 
     return Mockresponse(status_code=500, raise_error=True)
 
+def klaviyo_429_error(*args, **kwargs):
+
+    return Mockresponse(status_code=429, raise_error=True)
+
 def klaviyo_501_error(*args, **kwargs):
 
     return Mockresponse(status_code=501, raise_error=True)
@@ -158,6 +162,17 @@ class TestBackoff(unittest.TestCase):
             utils_.authed_get("", "", "")
         except utils_.KlaviyoInternalServiceError as e:
             self.assertEquals(str(e), "HTTP-error-code: 500, Error: Internal Service Error from Klaviyo.")
+
+    @mock.patch('time.sleep')
+    @mock.patch('requests.Session.request', side_effect=klaviyo_429_error)
+    def test_429_error(self, klaviyo_429_error, mocked_sleep, mocked_get_request_timeout):
+        """
+        Test that `authed_get` raise 429 error with proper message
+        """
+        try:
+            utils_.authed_get("", "", "")
+        except utils_.KlaviyoRateLimitError as e:
+            self.assertEquals(str(e), "HTTP-error-code: 429, Error: The API rate limit for your organization/application pairing has been exceeded.")
 
     @mock.patch('time.sleep')
     @mock.patch('requests.Session.request', side_effect=klaviyo_501_error)

--- a/tests/unittests/test_exception_handling.py
+++ b/tests/unittests/test_exception_handling.py
@@ -54,6 +54,10 @@ def klaviyo_404_error(*args, **kwargs):
 
     return Mockresponse(status_code=404, raise_error=True)
 
+def klaviyo_409_error(*args, **kwargs):
+
+    return Mockresponse(status_code=409, raise_error=True)
+
 def klaviyo_500_error(*args, **kwargs):
 
     return Mockresponse(status_code=500, raise_error=True)
@@ -151,6 +155,16 @@ class TestBackoff(unittest.TestCase):
             utils_.authed_get("", "", "")
         except utils_.KlaviyoNotFoundError as e:
             self.assertEquals(str(e), "HTTP-error-code: 404, Error: The requested resource doesn't exist.")
+
+    @mock.patch('requests.Session.request', side_effect=klaviyo_409_error)
+    def test_409_error(self, klaviyo_409_error, mocked_get_request_timeout):
+        """
+        Test that `authed_get` raise 409 error with proper message
+        """
+        try:
+            utils_.authed_get("", "", "")
+        except utils_.KlaviyoConflictError as e:
+            self.assertEquals(str(e), "HTTP-error-code: 409, Error: The API request cannot be completed because the requested operation would conflict with an existing item.")
 
     @mock.patch('time.sleep')
     @mock.patch('requests.Session.request', side_effect=klaviyo_500_error)

--- a/tests/unittests/test_exception_handling.py
+++ b/tests/unittests/test_exception_handling.py
@@ -212,4 +212,4 @@ class TestBackoff(unittest.TestCase):
         try:
             utils_.authed_get("", "", "")
         except utils_.KlaviyoServerTimeoutError as e:
-            self.assertEquals(str(e), "HTTP-error-code: 524, Error: Server server took too long to respond to the request.")
+            self.assertEquals(str(e), "HTTP-error-code: 524, Error: Server took too long to respond to the request.")


### PR DESCRIPTION
# Description of change
- Added backoff for 429, 501, 502, 503, 504, 524 error codes.
- Updated error handling to handle 409 error code with a proper error message.
- Added unit test cases to verify backoff.

# Manual QA steps
 - Raise HttpError manually with 429, 501, 502, 503, 504, and 524 error codes and verify that tap retry the error 3 times.
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
