### PR TITLE
TDL 18809 add replication key in metadata

### DIFF
--- a/tap_klaviyo/__init__.py
+++ b/tap_klaviyo/__init__.py
@@ -137,7 +137,7 @@ def get_available_metrics(api_key):
                         tap_stream_id=metric['id'],
                         key_properties="id",
                         replication_method='INCREMENTAL',
-                        replication_keys=["since"]
+                        replication_keys=["timestamp"]
                     )
                 )
 

--- a/tap_klaviyo/__init__.py
+++ b/tap_klaviyo/__init__.py
@@ -137,7 +137,7 @@ def get_available_metrics(api_key):
                         tap_stream_id=metric['id'],
                         key_properties="id",
                         replication_method='INCREMENTAL',
-                        replication_keys="since"
+                        replication_keys=["since"]
                     )
                 )
 

--- a/tap_klaviyo/__init__.py
+++ b/tap_klaviyo/__init__.py
@@ -47,7 +47,7 @@ class Stream(object):
                 schema = schema,
                 key_properties = self.key_properties,
                 valid_replication_keys=self.replication_keys, # Add replication key in the metadata of catalog
-                replication_method = self.replication_method,
+                replication_method = self.replication_method
             )
         )
 

--- a/tap_klaviyo/__init__.py
+++ b/tap_klaviyo/__init__.py
@@ -32,12 +32,13 @@ EVENT_MAPPINGS = {
 
 
 class Stream(object):
-    def __init__(self, stream, tap_stream_id, key_properties, replication_method):
+    def __init__(self, stream, tap_stream_id, key_properties, replication_method, replication_keys=None):
         self.stream = stream
         self.tap_stream_id = tap_stream_id
         self.key_properties = key_properties
         self.replication_method = replication_method
         self.metadata = []
+        self.replication_keys = replication_keys
 
     def to_catalog_dict(self):
         schema = load_schema(self.stream)
@@ -45,7 +46,8 @@ class Stream(object):
             metadata.get_standard_metadata(
                 schema = schema,
                 key_properties = self.key_properties,
-                replication_method = self.replication_method
+                valid_replication_keys=self.replication_keys, # Add replication key in the metadata of catalog
+                replication_method = self.replication_method,
             )
         )
 
@@ -134,7 +136,8 @@ def get_available_metrics(api_key):
                         stream=EVENT_MAPPINGS[metric['name']],
                         tap_stream_id=metric['id'],
                         key_properties="id",
-                        replication_method='INCREMENTAL'
+                        replication_method='INCREMENTAL',
+                        replication_keys="since"
                     )
                 )
 

--- a/tests/base.py
+++ b/tests/base.py
@@ -20,7 +20,7 @@ class KlaviyoBaseTest(unittest.TestCase):
     INCREMENTAL = "INCREMENTAL"
     FULL_TABLE = "FULL_TABLE"
     BOOKMARK = "bookmark"
-    REPLICATION_KEYS = "REPLICATION_KEYS"
+    REPLICATION_KEYS = "valid-replication-keys"
     START_DATE_FORMAT = "%Y-%m-%dT00:00:00Z"
     DATETIME_FMT = "%Y-%m-%dT%H:%M:%SZ"
     start_date = ""

--- a/tests/test_klaviyo_discovery.py
+++ b/tests/test_klaviyo_discovery.py
@@ -92,12 +92,10 @@ class DiscoveryTest(KlaviyoBaseTest):
                     expected_replication_method, actual_replication_method,
                 )
                 
-                # Currently, Tap is not writing the replication key in the metadata of the catalog
-                # https://jira.talendforge.org/browse/TDL-18809
-                # # verify replication keys match expections
-                # self.assertEqual(expected_replication_keys, actual_replication_keys,
-                #                  msg="expected replication key {} but actual is {}".format(
-                #                      expected_replication_keys, actual_replication_keys))
+                # verify replication keys match expections
+                self.assertEqual(expected_replication_keys, actual_replication_keys,
+                                 msg="expected replication key {} but actual is {}".format(
+                                     expected_replication_keys, actual_replication_keys))
                     
                 
                 # verify that if there is a replication key we are doing INCREMENTAL otherwise FULL

--- a/tests/test_klaviyo_discovery.py
+++ b/tests/test_klaviyo_discovery.py
@@ -67,10 +67,11 @@ class DiscoveryTest(KlaviyoBaseTest):
                     item.get("breadcrumb", ["properties", None])[1] for item in metadata
                     if item.get("metadata").get("inclusion") == "automatic"
                 )
-                actual_replication_keys = stream_properties[0].get(
-                    "metadata", {self.REPLICATION_KEYS: None}).get(self.REPLICATION_KEYS)
+                actual_replication_keys = set()
+                actual_replication_keys.add(stream_properties[0].get(
+                    "metadata", {self.REPLICATION_KEYS: None}).get(self.REPLICATION_KEYS))
                 
-                # verify there are no duplicate metadata entries
+                # verify to no duplicate metadata
                 for md in metadata:
                     self.assertEqual(metadata.count(md),1,msg="There is duplicated metadata in '{}' stream".format(stream))
                 
@@ -90,13 +91,11 @@ class DiscoveryTest(KlaviyoBaseTest):
                     expected_replication_method, actual_replication_method,
                 )
                 
-                # Currently, Tap is not writing the replication key in the metadata of the catalog 
-                # https://jira.talendforge.org/browse/TDL-18809
-                # # verify replication keys match expections
-                # if actual_replication_method==self.INCREMENTAL:
-                #     self.assertEqual(expected_replication_keys,actual_replication_keys)
-                # else:
-                #     self.assertIsNone(actual_replication_keys)
+                # verify replication keys match expections
+                if actual_replication_method==self.INCREMENTAL:
+                    self.assertEqual(expected_replication_keys,actual_replication_keys)
+                else:
+                    self.assertIsNone(next(iter(actual_replication_keys)))
                     
                 
                 # verify that if there is a replication key we are doing INCREMENTAL otherwise FULL

--- a/tests/test_klaviyo_discovery.py
+++ b/tests/test_klaviyo_discovery.py
@@ -69,9 +69,9 @@ class DiscoveryTest(KlaviyoBaseTest):
                 )
                 actual_replication_keys = set()
                 actual_replication_keys.add(stream_properties[0].get(
-                    "metadata", {self.REPLICATION_KEYS: None}).get(self.REPLICATION_KEYS))
+                    "metadata", {self.REPLICATION_KEYS: []}).get(self.REPLICATION_KEYS))
                 
-                # verify to no duplicate metadata
+                # verify there are no duplicate metadata entries
                 for md in metadata:
                     self.assertEqual(metadata.count(md),1,msg="There is duplicated metadata in '{}' stream".format(stream))
                 


### PR DESCRIPTION
# Description of change
- Added replication key in the metadata of catalog.
- Updated `discover` test case to verify replication key in the metadata

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
