### PR TITLE
TDL-19097 Data loss due to query parameter

### DIFF
--- a/tap_klaviyo/utils.py
+++ b/tap_klaviyo/utils.py
@@ -106,8 +106,11 @@ def get_starting_point(stream, state, start_date):
         return None
 
 
+# Decrease timestamp(maximum replication key value) by 1 second.
+# Because API returns records in which the replication key value is greater than the last saved bookmark value.
+# So, sometimes records with the same bookmark value may be lost.
 def get_latest_event_time(events):
-    return ts_to_dt(int(events[-1]['timestamp'])) if len(events) else None
+    return ts_to_dt(int(events[-1]['timestamp']) - 1) if len(events) else None
 
 # during 'Timeout' error there is also possibility of 'ConnectionError',
 # hence added backoff for 'ConnectionError' too.

--- a/tests/test_klaviyo_bookmark.py
+++ b/tests/test_klaviyo_bookmark.py
@@ -109,9 +109,13 @@ class BookmarkTest(KlaviyoBaseTest):
                     first_bookmark_value = first_bookmark_key_value.get(replication_key)
                     second_bookmark_value = second_bookmark_key_value.get(replication_key)
                     
-                    first_bookmark_value_ts = self.dt_to_ts(first_bookmark_value)
+                    # We are writing bookmark value 1 second less than the maximum bookmark value.
+                    # Because API returns records in which the replication key value is greater than the last saved bookmark value.
+                    # So, sometimes records with the same bookmark value may be lost.
+                    # That's why here we are adding 1 second to both bookmark values.
+                    first_bookmark_value_ts = self.dt_to_ts(first_bookmark_value) + 1
                     
-                    second_bookmark_value_ts = self.dt_to_ts(second_bookmark_value)
+                    second_bookmark_value_ts = self.dt_to_ts(second_bookmark_value) + 1
                     
                     simulated_bookmark_value = self.dt_to_ts(new_states['bookmarks'][stream][replication_key])
 


### PR DESCRIPTION
# Description of change
- Updated bookmarking logic to write bookmark value as 1 second less than the maximum replication key value.
- Updated bookmark integration test case to verify the same.

# Manual QA steps
 - Run sync mode and verify that the bookmark value is written as 1 second less than the maximum replication key value.
 - Run sync mode for a few pages and interrupt the sync. Again rerun the sync and verify that no data loss happens due to the query parameter.
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
