### PR TITLE
Version bump for Klavio

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 0.3.0
+  * Add missing tap tester tests [#52](https://github.com/singer-io/tap-klaviyo/pull/52)
+  * Backoff Error Handling [#51](https://github.com/singer-io/tap-klaviyo/pull/51)
+  * Added missing fields in schema [#54](https://github.com/singer-io/tap-klaviyo/pull/54)
+  * Add SMS Events stream [#54](https://github.com/singer-io/tap-klaviyo/pull/55)
+  * Add Replication Key in metadata [#53](https://github.com/singer-io/tap-klaviyo/pull/53)
+  * Add null to schema types [#58](https://github.com/singer-io/tap-klaviyo/pull/58)
+  * Change query parameter to prevent data loss [#57](https://github.com/singer-io/tap-klaviyo/pull/57)
+
 ## 0.2.1
   * Added Request Timeout [#47](https://github.com/singer-io/tap-klaviyo/pull/47)
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='tap-klaviyo',
-      version='0.2.1',
+      version='0.3.0',
       description='Singer.io tap for extracting data from the Klaviyo API',
       author='Stitch',
       url='http://singer.io',


### PR DESCRIPTION
# Description of change

- Add missing tap tester tests [#52](https://github.com/singer-io/tap-klaviyo/pull/52)
- Backoff Error Handling [#51](https://github.com/singer-io/tap-klaviyo/pull/51)
- Added missing fields in schema [#54](https://github.com/singer-io/tap-klaviyo/pull/54)
- Add SMS Events stream [#54](https://github.com/singer-io/tap-klaviyo/pull/55)
- Add Replication Key in metadata [#53](https://github.com/singer-io/tap-klaviyo/pull/53)
- Add null to schema types [#58](https://github.com/singer-io/tap-klaviyo/pull/58)
- Change query parameter to prevent data loss [#57](https://github.com/singer-io/tap-klaviyo/pull/57)

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
