### PR TITLE
Changing EVENT_MAPPINGS to reflect recent Klaviyo schema name changes

### DIFF
--- a/tap_klaviyo/__init__.py
+++ b/tap_klaviyo/__init__.py
@@ -29,13 +29,13 @@ EVENT_MAPPINGS = {
     "Updated Email Preferences": "update_email_preferences",
     "Dropped Email": "dropped_email",
     "Clicked SMS": "clicked_sms",
-    "Consented to Receive SMS": "consented_to_receive",
+    "Subscribed to SMS Marketing": "consented_to_receive",
     "Failed to Deliver SMS": "failed_to_deliver",
     "Failed to deliver Automated Response SMS": "failed_to_deliver_automated_response",
     "Received Automated Response SMS": "received_automated_response",
     "Received SMS": "received_sms",
     "Sent SMS": "sent_sms",
-    "Unsubscribed from SMS": "unsubscribed_from_sms"
+    "Unsubscribed from SMS Marketing": "unsubscribed_from_sms"
 }
 
 


### PR DESCRIPTION
Klaviyo has recently changed the name of their SMS Subscribe and Unsubscribe metrics. This results in the current klaviyo tap missing the new metrics and no longer updating the `consented_to_receive` or `unsubscribed_from_sms` schemas. You can manually check with an API call using the following documentation:
 https://developers.klaviyo.com/en/v1-2/reference/get-metrics

# Description of change
The dict keys for `consented_to_receive` or `unsubscribed_from_sms` have been updated to reflect recent Klaviyo changes.

# Manual QA steps
 - Run HTTP request from https://developers.klaviyo.com/en/v1-2/reference/get-metrics to return updated Klaviyo schema. Run tap with updated names to make sure they were being read correctly.
 
# Risks
 - Old names may still be in use in certain Klaviyo versions, though this tap uses the oldest version available.
 
# Rollback steps
 - revert this branch
