### PR TITLE
api version upgrade to "2024-10-15"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.1.0
+  * Klaviyo API version upgrade to v2024-10-15 [#74](https://github.com/singer-io/tap-klaviyo/pull/74)
+
 ## 1.0.1
   * Bump requests from 2.31.0 to 2.32.3 [#73](https://github.com/singer-io/tap-klaviyo/pull/73)
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup
 
 setup(name='tap-klaviyo',
-      version='1.0.1',
+      version='1.1.0',
       description='Singer.io tap for extracting data from the Klaviyo API',
       author='Stitch',
       url='http://singer.io',

--- a/tap_klaviyo/__init__.py
+++ b/tap_klaviyo/__init__.py
@@ -9,7 +9,7 @@ from tap_klaviyo.utils import get_incremental_pull, get_full_pulls, get_all_usin
 
 LOGGER = singer.get_logger()
 
-API_VERSION = "2024-02-15"
+API_VERSION = "2024-10-15"
 
 # For stream global_exclusions, data related to suppressed users can be found in the /api/profiles endpoint
 ENDPOINTS = {


### PR DESCRIPTION
# Description of change
- API version upgrade to "2024-10-15" (As per the doc ([https://developers.klaviyo.com/en/v2024-05-15/docs/api_versioning_and_deprecation_policy)](https://developers.klaviyo.com/en/v2024-05-15/docs/api_versioning_and_deprecation_policy)), it will be deprecated on 2025-02-15 though it is going to retire on 2026-02-15.)
- Bump version changes in CHANGELOG.md and setup.py

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
